### PR TITLE
Fix config yaml to pass pointcloudFrame correctly

### DIFF
--- a/sensorConfig.md
+++ b/sensorConfig.md
@@ -8,8 +8,7 @@
 %YAML 1.2
 ---
 # Configuration
-sensor_pointcloud:
-    pointcloudFrame: map
+pointcloudFrame: map
 ```
 This portion declares:
 1. The configuration file format (YAML 1.2)

--- a/sensorConfig.yaml
+++ b/sensorConfig.yaml
@@ -1,8 +1,7 @@
 %YAML 1.2
 ---
 # Configuration
-sensor_pointcloud:
-    pointcloudFrame: map
+pointcloudFrame: map
 
 # List of sensors
 sensors:


### PR DESCRIPTION
This PR fixes `pointcloudFrame` parameter location because it should be just under `sensor_pointcloud_node`:
https://github.com/eliotlim/sensor_pointcloud/blob/b0e83015558199c717e9586a3611d594bcd840b9/src/sensor_pointcloud_node.cpp#L40
https://github.com/eliotlim/sensor_pointcloud/blob/b0e83015558199c717e9586a3611d594bcd840b9/src/sensor_pointcloud_node.cpp#L26
https://github.com/eliotlim/sensor_pointcloud/blob/b0e83015558199c717e9586a3611d594bcd840b9/src/sensor_pointcloud_node.cpp#L35
https://github.com/eliotlim/sensor_pointcloud/blob/b0e83015558199c717e9586a3611d594bcd840b9/src/sensor_pointcloud_node.cpp#L31

This PR probably complements https://github.com/eliotlim/sensor_pointcloud/commit/b0e83015558199c717e9586a3611d594bcd840b9